### PR TITLE
Ops 5439 k8s loggery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ LABEL CostCenter="Ops" Application="kubernetes"
 # yet in Alpine's main package repo.
 RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ filebeat
 
-COPY configs/containers.yml /etc/filebeat/containers.yml
-COPY configs/stdin.yml      /etc/filebeat/stdin.yml
+COPY configs/*.yml /etc/filebeat/
 
 ENTRYPOINT ["/usr/bin/filebeat", "-e", "-v"]
 CMD ["-c", "/etc/filebeat/containers.yml"]

--- a/configs/containers.yml
+++ b/configs/containers.yml
@@ -1,18 +1,29 @@
 #
 # This config file reads logs for all containers running on this host
 #
+
+filebeat.registry_file: /var/log/containers/filebeat_registry
+
 filebeat:
   prospectors:
     -
-      encoding: utf-8
-      input_type: log
-      document_type: kubernetes-docker
       paths:
         - "/var/log/containers/*.log"
-      scan_frequency: 10s
+      symlinks: true
+      json.message_key: log
+      json.keys_under_root: true
+      json.add_error_key: true
+      multiline.pattern: '^\s'
+      multiline.match: after
+      document_type: kubernetes-docker
       fields:
         application: docker
+        host: ${FILEBEAT_HOST:${HOSTNAME}}
+        logstash: ${LOGSTASH_HOST}
+      fields_under_root: false
 
 output:
   logstash:
       hosts: [ "${LOGSTASH_HOST}:${LOGSTASH_PORT:5044}" ]
+
+logging.level: ${LOG_LEVEL:error}

--- a/examples/kubernetes/filebeat.yml
+++ b/examples/kubernetes/filebeat.yml
@@ -4,6 +4,7 @@ metadata:
   name: filebeat
   namespace: kube-system
   labels:
+    app: filebeat
     k8s-app: filebeat
     kubernetes.io/cluster-service: "true"
 spec:
@@ -16,6 +17,7 @@ spec:
       containers:
       - name: filebeat
         image: jwplayer/k8s-filebeat:latest
+        imagePullPolicy: Always
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
This PR changes the config of the `containers` prospector to do a couple of things:

* creates a mounted registry_file, this prevents log replay when the daemonset is restarted
* Preparses the JSON logs in the prospector. Plaintext logs are forwarded as such.
* Explicitly adds `imagePullPolicy: Always` to the k8s example